### PR TITLE
add: get/post weather api

### DIFF
--- a/src/app/api/external/visualcrossing.ts
+++ b/src/app/api/external/visualcrossing.ts
@@ -1,0 +1,21 @@
+import { ExternalWeather } from "@/app/types/Weather";
+
+export const getWeather = async (datetime: string, address: string) => {
+  try {
+    const response = await fetch(
+      `https://weather.visualcrossing.com/VisualCrossingWebServices/rest/services/timeline/${address}/${datetime}/${datetime}?unitGroup=metric&key=${process.env.VISUALCROSSING_API_KEY}&contentType=json`,
+      {
+        cache: "no-store",
+      }
+    );
+    if (response.ok) {
+      const weather: ExternalWeather = await response.json();
+      return weather;
+    } else {
+      throw new Error(String(await response.text()))
+    }
+  } catch (error: any) {
+    console.log(error.message)
+    return null;
+  }
+};

--- a/src/app/api/weather/create.ts
+++ b/src/app/api/weather/create.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { ExternalWeather } from "@/app/types/Weather";
+import { Weather } from "@prisma/client";
+
+export const postWeather = async (externalWeather: ExternalWeather) => {
+  const address = externalWeather.address;
+  const datetime = new Date(externalWeather.days[0].datetime);
+  const temp = externalWeather.days[0].temp;
+  const tempmax = externalWeather.days[0].tempmax;
+  const tempmin = externalWeather.days[0].tempmin;
+  const precipprob = externalWeather.days[0].precipprob;
+  const windspeed = externalWeather.days[0].windspeed;
+  const uvindex = externalWeather.days[0].uvindex;
+  const conditions = externalWeather.days[0].conditions;
+  const icon = externalWeather.days[0].icon;
+  const weather = {
+    address,
+    datetime,
+    temp,
+    tempmax,
+    tempmin,
+    precipprob,
+    windspeed,
+    uvindex,
+    conditions,
+    icon,
+  };
+
+  try {
+    const response = await fetch(`${process.env.ROOT_URL}/api/weather`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        ...weather,
+      }),
+    });
+    const data: { message: string; weather: Weather } = await response.json();
+    return data.weather;
+  } catch (error: any) {
+    console.log(error.message);
+    return null;
+  }
+};

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -1,0 +1,87 @@
+import { PrismaClient, Weather } from "@prisma/client";
+import { NextRequest } from "next/server";
+import { getWeather } from "../external/visualcrossing";
+import { postWeather } from "./create";
+import { WeatherData } from "@/app/types/Weather";
+
+const prisma = new PrismaClient();
+
+export async function main() {
+  try {
+    await prisma.$connect();
+  } catch (error) {
+    return Error("failed db connect");
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const params = request.nextUrl.searchParams;
+    const datetime = String(params.get("datetime"));
+    const address = String(params.get("address"));
+    await main();
+    const weather = await prisma.weather.findFirst({
+      where: {
+        datetime: new Date(datetime),
+        address: address,
+      },
+    });
+    // DBに存在していればDBから取得
+    if (weather !== null) {
+      return Response.json(
+        {
+          message: "Successfully retrieved weather data from database",
+          weather: { ...weather, id: Number(weather.id) },
+        },
+        { status: 200 }
+      );
+    // DBに存在していなければ外部APIから取得しDBに保存
+    } else {
+      const externalWeather = await getWeather(datetime, address);
+
+      if (externalWeather === null || externalWeather === undefined) {
+        throw new Error("Can Not Get External Weather Data");
+      }
+      const createdWeather: Weather | null = await postWeather(externalWeather);
+      if (createdWeather !== null) {
+        return Response.json(
+          {
+            message: "Successfully retrieved weather data from visualcrossing",
+            weather: createdWeather,
+          },
+          { status: 200 }
+        );
+      } else {
+        throw new Error("Can Not Create Weather Data");
+      }
+    }
+  } catch (error: any) {
+    return Response.json(
+      { message: error.message, weather: null },
+      { status: 500 }
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const weatherData: WeatherData = await request.json();
+    await main();
+    const weather = await prisma.weather.create({
+      data: weatherData,
+    });
+    return Response.json(
+      { message: "Success", weather: { ...weather, id: Number(weather.id) } },
+      { status: 200 }
+    );
+  } catch (error: any) {
+    return Response.json(
+      { message: error.message, weather: null },
+      { status: 500 }
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/src/app/types/Weather.ts
+++ b/src/app/types/Weather.ts
@@ -1,0 +1,142 @@
+export type ExternalWeather = {
+  queryCost: number;
+  latitude: number;
+  longitude: number;
+  resolvedAddress: string;
+  address: string;
+  timezone: string;
+  tzoffset: number;
+  description: string;
+  days: Day[];
+  alerts: string[];
+  stations: Stations;
+  currentConditions: CurrentConditions;
+};
+
+type Day = {
+  datetime: string;
+  datetimeEpoch: number;
+  tempmax: number;
+  tempmin: number;
+  temp: number;
+  feelslikemax: number;
+  feelslikemin: number;
+  feelslike: number;
+  dew: number;
+  humidity: number;
+  precip: number;
+  precipprob: number;
+  precipcover: number;
+  preciptype: string[];
+  snow: number;
+  snowdepth: number;
+  windgust: number;
+  windspeed: number;
+  winddir: number;
+  pressure: number;
+  cloudcover: number;
+  visibility: number;
+  solarradiation: number;
+  solarenergy: number;
+  uvindex: number;
+  severerisk: number;
+  sunrise: string;
+  sunriseEpoch: number;
+  sunset: string;
+  sunsetEpoch: number;
+  moonphase: number;
+  conditions: string;
+  description: string;
+  icon: string;
+  stations: string[];
+  source: string;
+  hours: Hour[];
+};
+
+type Hour = {
+  datetime: string;
+  datetimeEpoch: number;
+  temp: number;
+  feelslike: number;
+  humidity: number;
+  dew: number;
+  precip: number | null;
+  precipprob: number;
+  snow: number;
+  snowdepth: number;
+  preciptype: string[] | null;
+  windgust: number;
+  windspeed: number;
+  winddir: number;
+  pressure: number;
+  visibility: number;
+  cloudcover: number;
+  solarradiation: number;
+  solarenergy: number;
+  uvindex: number;
+  severerisk: number;
+  conditions: string;
+  icon: string;
+  stations: string[];
+  source: string;
+};
+
+type Stations = {
+  [key: string]: Station;
+};
+
+type Station = {
+  distance: number;
+  latitude: number;
+  longitude: number;
+  useCount: number;
+  id: string;
+  name: string;
+  quality: number;
+  contribution: number;
+};
+
+type CurrentConditions = {
+  datetime: string;
+  datetimeEpoch: number;
+  temp: number;
+  feelslike: number;
+  humidity: number;
+  dew: number;
+  precip: number | null;
+  precipprob: number;
+  snow: number;
+  snowdepth: number;
+  preciptype: string[] | null;
+  windgust: number | null;
+  windspeed: number;
+  winddir: number;
+  pressure: number;
+  visibility: number;
+  cloudcover: number;
+  solarradiation: number;
+  solarenergy: number;
+  uvindex: number;
+  conditions: string;
+  icon: string;
+  stations: string[];
+  source: string;
+  sunrise: string;
+  sunriseEpoch: number;
+  sunset: string;
+  sunsetEpoch: number;
+  moonphase: number;
+};
+
+export type WeatherData = {
+  address: string;
+  datetime: Date;
+  temp: number;
+  tempmax: number;
+  tempmin: number;
+  precipprob: number;
+  windspeed: number;
+  uvindex: number;
+  conditions: string;
+  icon: string;
+};


### PR DESCRIPTION
-  weatherテーブルから日付、地名を指定して天気情報を取得する（/api/weather?datetime={datetime}&address={address}）
-  weatherテーブルに、天気情報を保存する（/api/weather）
- DBに天気情報がなければvisualcrossingから取得しDBに保存する